### PR TITLE
proximal gradient method @ group lasso fixed

### DIFF
--- a/pyglmnet/pyglmnet.py
+++ b/pyglmnet/pyglmnet.py
@@ -531,6 +531,7 @@ class GLM(BaseEstimator):
             result[idxs_to_update] = (beta[idxs_to_update] -
                                       thresh * beta[idxs_to_update] /
                                       group_norms[idxs_to_update])
+            result[~idxs_to_update] = 0.0
 
             return result
 

--- a/tests/test_pyglmnet.py
+++ b/tests/test_pyglmnet.py
@@ -122,16 +122,40 @@ def test_group_lasso():
     beta = np.random.normal(0.0, 1.0, n_features)
     beta[groups == 2] = 0.
 
-    # create an instance of the GLM class
-    glm_group = GLM(distr='softplus', alpha=1.)
+    lams = [0.5, 0.3237394, 0.2096144, 0.13572088, 0.08787639,
+            0.0568981, 0.03684031, 0.02385332, 0.01544452, 0.01]
+    alpha = 1.0
 
-    # simulate training data
-    Xr = np.random.normal(0.0, 1.0, [n_samples, n_features])
-    yr = simulate_glm(glm_group.distr, beta0, beta, Xr)
+    for lam in lams:
+        # create an instance of the GLM class
+        glm_group = GLM(distr='softplus', alpha=alpha, reg_lambda=lam, group=groups)
 
-    # scale and fit
-    scaler = StandardScaler().fit(Xr)
-    glm_group.fit(scaler.transform(Xr), yr)
+        # simulate training data
+        np.random.seed(0)
+        Xr = np.random.normal(0.0, 1.0, [n_samples, n_features])
+        yr = simulate_glm(glm_group.distr, beta0, beta, Xr)
+
+        # scale and fit
+        scaler = StandardScaler().fit(Xr)
+        glm_group.fit(scaler.transform(Xr), yr)
+
+        # count number of nonzero coefs for each group.
+        # in each group, coef must be [all nonzero] or [all zero].
+        unique_group_idxs = np.unique(groups)
+        beta = glm_group.beta_
+        group_norms = np.abs(beta)
+        for target_group_idx in unique_group_idxs:
+            if target_group_idx == 0:
+                continue
+
+            target_beta = beta[groups == target_group_idx]
+            n_nonzero = (target_beta != 0.0).sum()
+            assert n_nonzero in (len(target_beta), 0)
+            group_norms[groups == target_group_idx] = np.linalg.norm(beta[groups == target_group_idx], 2)
+
+        # beta where those absolute values are smaller than the threshold must be 0.
+        thresh = lam * alpha
+        assert (beta[group_norms <= thresh] == 0.0).all()
 
 
 def test_glmnet():

--- a/tests/test_pyglmnet.py
+++ b/tests/test_pyglmnet.py
@@ -122,10 +122,8 @@ def test_group_lasso():
     beta = np.random.normal(0.0, 1.0, n_features)
     beta[groups == 2] = 0.
 
-    alpha = 1.0
-    reg_lambda = 0.2
     # create an instance of the GLM class
-    glm_group = GLM(distr='softplus', alpha=alpha, reg_lambda=reg_lambda, group=groups)
+    glm_group = GLM(distr='softplus', alpha=1., reg_lambda=0.2, group=groups)
 
     # simulate training data
     Xr = np.random.normal(0.0, 1.0, [n_samples, n_features])

--- a/tests/test_pyglmnet.py
+++ b/tests/test_pyglmnet.py
@@ -147,7 +147,9 @@ def test_group_lasso():
         assert n_nonzero in (len(target_beta), 0)
 
     # one of the groups must be [all zero]
-    assert (beta[groups != 0] == 0.0).any()
+    assert np.any([beta[groups == group_id].sum() == 0 \
+                   for group_id in group_ids if group_id != 0])
+
 
 def test_glmnet():
     """Test glmnet."""

--- a/tests/test_pyglmnet.py
+++ b/tests/test_pyglmnet.py
@@ -137,21 +137,14 @@ def test_group_lasso():
 
     # count number of nonzero coefs for each group.
     # in each group, coef must be [all nonzero] or [all zero].
-    unique_group_idxs = np.unique(groups)
-    beta = glm_group.beta_
-    group_norms = np.zeros_like(beta)
-    for target_group_idx in unique_group_idxs:
-        if target_group_idx == 0:
-            group_norms[groups == target_group_idx] =  np.abs(beta)[groups == target_group_idx]
+    group_ids = np.unique(groups)
+    for group_id in group_ids:
+        if group_id == 0:
+            continue
 
-        target_beta = beta[groups == target_group_idx]
+        target_beta = beta[groups == group_id]
         n_nonzero = (target_beta != 0.0).sum()
         assert n_nonzero in (len(target_beta), 0)
-        group_norms[groups == target_group_idx] = np.linalg.norm(target_beta, 2)
-
-    # beta where those absolute values are smaller than the threshold must be 0.
-    thresh = reg_lambda * alpha
-    assert (beta[group_norms <= thresh] == 0.0).all()
 
 
 def test_glmnet():

--- a/tests/test_pyglmnet.py
+++ b/tests/test_pyglmnet.py
@@ -126,6 +126,7 @@ def test_group_lasso():
     glm_group = GLM(distr='softplus', alpha=1., reg_lambda=0.2, group=groups)
 
     # simulate training data
+    np.random.seed(glm_group.random_state)
     Xr = np.random.normal(0.0, 1.0, [n_samples, n_features])
     yr = simulate_glm(glm_group.distr, beta0, beta, Xr)
 
@@ -135,6 +136,7 @@ def test_group_lasso():
 
     # count number of nonzero coefs for each group.
     # in each group, coef must be [all nonzero] or [all zero].
+    beta = glm_group.beta_
     group_ids = np.unique(groups)
     for group_id in group_ids:
         if group_id == 0:
@@ -144,6 +146,8 @@ def test_group_lasso():
         n_nonzero = (target_beta != 0.0).sum()
         assert n_nonzero in (len(target_beta), 0)
 
+    # one of the groups must be [all zero]
+    assert (beta[groups != 0] == 0.0).any()
 
 def test_glmnet():
     """Test glmnet."""


### PR DESCRIPTION
In proximal gradient method,  weights where those absolute values are smaller than the threshold must be 0.