### PR TITLE
removing the word install from development installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ $ git clone http://github.com/glm-tools/pyglmnet
 Install `pyglmnet` using `setup.py` as follows
 
 ```bash
-$ python setup.py develop install
+$ python setup.py develop
 ```
 
 ### Getting Started

--- a/README.rst
+++ b/README.rst
@@ -110,7 +110,7 @@ Install ``pyglmnet`` using ``setup.py`` as follows
 
 .. code:: bash
 
-    $ python setup.py develop install
+    $ python setup.py develop
 
 Getting Started
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
This changes `python setup.py develop install` to `python setup.py develop` in both README. I left the Makefile unchanged since I don't know how to work with those. See issue https://github.com/glm-tools/pyglmnet/issues/254