### PR TITLE
have GLM objects record the number of iterations and convergence status

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -19,6 +19,7 @@ Changelog
     - Add support for running :class:`sklearn.model_selection.GridSearchCV` on :class:`pyglmnet.GLM` objects by `Mainak Jas`_.
     - Improved testing of gradients for optimization by `Mainak Jas`_ and `Pavan Ramkumar`_.
     - Improved testing of estimated coefficients at convergence by `Mainak Jas`_ and `Pavan Ramkumar`_
+    - Add `converged` flag and `n_iter` counter to :class:`pyglmnet.GLM` by `Peter Foley`_
  
 BUG
 ~~~

--- a/pyglmnet/pyglmnet.py
+++ b/pyglmnet/pyglmnet.py
@@ -755,12 +755,12 @@ class GLM(BaseEstimator):
                 convergence_metric = np.linalg.norm(grad)
                 logger.debug("convergence_metric: %f" % convergence_metric)
                 if (t > 1) and (convergence_metric < tol):
-                        self.converged = True
-                        self.n_iter += t
-                        msg = ('\tConverged in {0:d} iterations'
-                               .format(self.n_iter))
-                        logger.info(msg)
-                        break
+                    self.converged = True
+                    self.n_iter += t
+                    msg = ('\tConverged in {0:d} iterations'
+                           .format(self.n_iter))
+                    logger.info(msg)
+                    break
                 beta = beta - self.learning_rate * grad
 
             elif self.solver == 'cdfast':
@@ -771,12 +771,12 @@ class GLM(BaseEstimator):
                 convergence_metric = np.linalg.norm(beta - beta_old)
                 logger.debug("convergence_metric: %f" % convergence_metric)
                 if (t > 1) and (convergence_metric < tol):
-                        self.converged = True
-                        self.n_iter += t
-                        msg = ('\tConverged in {0:d} iterations'
-                               .format(self.n_iter))
-                        logger.info(msg)
-                        break
+                    self.converged = True
+                    self.n_iter += t
+                    msg = ('\tConverged in {0:d} iterations'
+                           .format(self.n_iter))
+                    logger.info(msg)
+                    break
             # Apply proximal operator
             beta[1:] = self._prox(beta[1:], reg_lambda * alpha)
 

--- a/pyglmnet/pyglmnet.py
+++ b/pyglmnet/pyglmnet.py
@@ -797,7 +797,7 @@ class GLM(BaseEstimator):
                    ' Last convergence metric was {1:f}'
                    ' and convergence threshold {2:f}.'
                    ).format(self.n_iter, convergence_metric, tol)
-            logger.warn(msg)
+            logger.warning(msg)
 
         # Update the estimated variables
         self.beta0_ = beta[0]

--- a/pyglmnet/pyglmnet.py
+++ b/pyglmnet/pyglmnet.py
@@ -1,6 +1,7 @@
 """Python implementation of elastic-net regularized GLMs."""
 
 from copy import deepcopy
+from math import inf
 
 import numpy as np
 from scipy.special import expit
@@ -498,6 +499,8 @@ class GLM(BaseEstimator):
         self.solver = solver
         self.learning_rate = learning_rate
         self.max_iter = max_iter
+        self.n_iter = 0
+        self.converged = False
         self.beta0_ = None
         self.beta_ = None
         self.ynull_ = None
@@ -741,16 +744,23 @@ class GLM(BaseEstimator):
 
         # Iterative updates
         for t in range(0, self.max_iter):
+            logger.info("t: %i" % t)
+            convergence_metric = inf
             if self.solver == 'batch-gradient':
                 grad = _grad_L2loss(self.distr,
                                     alpha, self.Tau,
                                     reg_lambda, X, y, self.eta,
                                     beta)
                 # Converged if the norm(gradient) < tol
-                if (t > 1) and (np.linalg.norm(grad) < tol):
-                    msg = ('\tConverged in {0:d} iterations'.format(t))
-                    logger.info(msg)
-                    break
+                convergence_metric = np.linalg.norm(grad)
+                logger.debug("convergence_metric: %f" % convergence_metric)
+                if (t > 1) and (convergence_metric < tol):
+                        self.converged = True
+                        self.n_iter += t
+                        msg = ('\tConverged in {0:d} iterations'
+                               .format(self.n_iter))
+                        logger.info(msg)
+                        break
                 beta = beta - self.learning_rate * grad
 
             elif self.solver == 'cdfast':
@@ -758,10 +768,15 @@ class GLM(BaseEstimator):
                 beta = \
                     self._cdfast(X, y, ActiveSet, beta, reg_lambda)
                 # Converged if the norm(update) < tol
-                if (t > 1) and (np.linalg.norm(beta - beta_old) < tol):
-                    msg = ('\tConverged in {0:d} iterations'.format(t))
-                    logger.info(msg)
-                    break
+                convergence_metric = np.linalg.norm(beta - beta_old)
+                logger.debug("convergence_metric: %f" % convergence_metric)
+                if (t > 1) and (convergence_metric < tol):
+                        self.converged = True
+                        self.n_iter += t
+                        msg = ('\tConverged in {0:d} iterations'
+                               .format(self.n_iter))
+                        logger.info(msg)
+                        break
             # Apply proximal operator
             beta[1:] = self._prox(beta[1:], reg_lambda * alpha)
 
@@ -773,6 +788,16 @@ class GLM(BaseEstimator):
             # Compute and save loss if callbacks are requested
             if callable(self.callback):
                 self.callback(beta)
+        else:
+            # Warn if it hit max_iter without converging
+            self.converged = False
+            self.n_iter += t + 1
+            msg = ('\t'
+                   'Failed to converge after {0:d} iterations.'
+                   ' Last convergence metric was {1:f}'
+                   ' and convergence threshold {2:f}.'
+                   ).format(self.n_iter, convergence_metric, tol)
+            logger.warn(msg)
 
         # Update the estimated variables
         self.beta0_ = beta[0]

--- a/pyglmnet/pyglmnet.py
+++ b/pyglmnet/pyglmnet.py
@@ -743,9 +743,9 @@ class GLM(BaseEstimator):
             ActiveSet = np.ones(n_features + 1)     # init active set
 
         # Iterative updates
+        convergence_metric = inf
         for t in range(0, self.max_iter):
             logger.info("t: %i" % t)
-            convergence_metric = inf
             if self.solver == 'batch-gradient':
                 grad = _grad_L2loss(self.distr,
                                     alpha, self.Tau,

--- a/pyglmnet/pyglmnet.py
+++ b/pyglmnet/pyglmnet.py
@@ -745,7 +745,7 @@ class GLM(BaseEstimator):
         # Iterative updates
         convergence_metric = inf
         for t in range(0, self.max_iter):
-            logger.info("t: %i" % t)
+            logger.debug("t: %i" % t)
             if self.solver == 'batch-gradient':
                 grad = _grad_L2loss(self.distr,
                                     alpha, self.Tau,


### PR DESCRIPTION
This records the number of iterations within the GLM object, and whether or not the `fit()` iterations stopped because it converged or because it hit `max_iter`. It also logs a warning if `max_iter` is reached before convergence.

In the current pyglmnet master branch, the only indication of convergence is in the logs, so this change makes it easier to check convergence programmatically.

It passes`nosetests . --with-coverage` locally, and `git diff main/master -U0 | flake8 --diff -` flags no pep8 violations.