### PR TITLE
Fix cdfast convergence

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -23,6 +23,7 @@ Changelog
 BUG
 ~~~
 
+    - Fixed z cache inconsistency in cdfast when alpha and reg_lambda are nonzero by `Peter Foley`_. 
     - Fixed incorrect usage of the random_state parameter by `Giovanni De Toni`_.
     - Fixed incorrect proximal operator for group lasso by `Yu Umegaki`_.
     - Changed stopping criteria for convergence (a threshold on the change in objective value) which
@@ -71,3 +72,4 @@ Changelog
 .. _Giovanni De Toni: https://github.com/geektoni
 .. _Beibin Li: https://github.com/BeibinLi
 .. _Scott Otterson: https://github.com/notuntoward
+.. _Peter Foley: https://github.com/peterfoley

--- a/tests/test_pyglmnet.py
+++ b/tests/test_pyglmnet.py
@@ -294,7 +294,8 @@ def test_cv():
     glmcv.fit(X, y)
 
 
-def test_compare_sklearn():
+@pytest.mark.parametrize("solver", ['batch-gradient', 'cdfast'])
+def test_compare_sklearn(solver):
     """Test results against sklearn."""
 
     def rmse(a, b):
@@ -311,7 +312,7 @@ def test_compare_sklearn():
     clf = ElasticNet(alpha=alpha, l1_ratio=l1_ratio, tol=1e-5)
     clf.fit(X, Y)
     glm = GLM(distr='gaussian', alpha=l1_ratio, reg_lambda=alpha,
-              solver='cdfast', tol=1e-5, max_iter=50)
+              solver=solver, tol=1e-5, max_iter=70)
     glm.fit(X, Y)
 
     y_sk = clf.predict(X)

--- a/tests/test_pyglmnet.py
+++ b/tests/test_pyglmnet.py
@@ -343,10 +343,8 @@ def test_cdfast(distr):
 
     # test cdfast
     ActiveSet = np.ones(n_features + 1)
-    beta_ret, z_ret = glm._cdfast(X, y, z,
-                                  ActiveSet, beta_, glm.reg_lambda)
+    beta_ret = glm._cdfast(X, y, ActiveSet, beta_, glm.reg_lambda)
     assert(beta_ret.shape == beta_.shape)
-    assert(z_ret.shape == z.shape)
 
 
 def test_fetch_datasets():


### PR DESCRIPTION
fixes #275 

changes test_glmnet to include tests with with nonzero lambda. Changes `GLM(solver='cdfast').fit()` execution path to recalculate `z` each time since it is actually invalidated on each iteration.

To speed up my testing I also added a manifest to make the package directly pip-installable, which is likely a useful addition even though it's not strictly related to the fix.