### PR TITLE
Parameterized tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,19 +4,25 @@ env:
     - PYTHON=3.5
     - PYTHON=3.6
     - PYTHON=3.7
+
 before_install:
   - wget -q http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh
   - ./miniconda.sh -b -p /home/travis/miniconda
   - export PATH=/home/travis/miniconda/bin:$PATH
   - conda update --yes conda
+
 install:
     - conda create -n testenv --yes pip python=$PYTHON
     - source activate testenv
     - conda install --yes --file requirements.txt
     - python setup.py develop
+
 script:
-    - py.test --cov=pyglmnet tests/
-    - flake8 --count pyglmnet
+    - # Run tests, show verbose output and print the top 10 slowest running tests
+    - py.test --cov=pyglmnet tests/ --verbose --durations=10
+    - # Run flake8 to check that package and tests adhere to PEP8
+    - flake8 --count pyglmnet tests
+
 after_success:
     - bash <(curl -s https://codecov.io/bash)

--- a/tests/test_pyglmnet.py
+++ b/tests/test_pyglmnet.py
@@ -14,12 +14,11 @@ from sklearn.model_selection import GridSearchCV, cross_val_score, KFold
 from pyglmnet import (GLM, GLMCV, _grad_L2loss, _L2loss, simulate_glm,
                       _gradhess_logloss_1d, _loss, datasets)
 
-DISTRIBUTIONS = ['gaussian', 'binomial', 'softplus', 'poisson', 'probit', 'gamma']
+DISTRIBUTIONS = ['gaussian', 'binomial', 'softplus',
+                 'poisson', 'probit', 'gamma']
 
 
-@pytest.mark.parametrize(
-    "distr", DISTRIBUTIONS
-)
+@pytest.mark.parametrize("distr", DISTRIBUTIONS)
 def test_gradients(distr):
     """Test gradient accuracy."""
     # data
@@ -152,9 +151,8 @@ def test_group_lasso():
     assert np.any([beta[groups == group_id].sum() == 0
                    for group_id in group_ids if group_id != 0])
 
-@pytest.mark.parametrize(
-    "distr", DISTRIBUTIONS
-)
+
+@pytest.mark.parametrize("distr", DISTRIBUTIONS)
 def test_glmnet(distr):
     """Test glmnet."""
     raises(ValueError, GLM, distr='blah')
@@ -168,13 +166,11 @@ def test_glmnet(distr):
     beta = 1. / (np.float(n_features) + 1.) * \
         np.random.normal(0.0, 1.0, (n_features,))
 
-
     solvers = ['batch-gradient', 'cdfast']
 
     score_metric = 'pseudo_R2'
     learning_rate = 2e-1
     random_state = 0
-
 
     betas_ = list()
     for solver in solvers:
@@ -234,9 +230,8 @@ def test_glmnet(distr):
     glm_poisson.fit_predict(X_train, y_train)
     raises(ValueError, glm_poisson.fit_predict, X_train[None, ...], y_train)
 
-@pytest.mark.parametrize(
-    "distr", DISTRIBUTIONS
-)
+
+@pytest.mark.parametrize("distr", DISTRIBUTIONS)
 def test_glmcv(distr):
     """Test GLMCV class."""
     raises(ValueError, GLM, distr='blah')
@@ -297,9 +292,7 @@ def test_cv():
     glmcv.fit(X, y)
 
 
-@pytest.mark.parametrize(
-    "distr", DISTRIBUTIONS
-)
+@pytest.mark.parametrize("distr", DISTRIBUTIONS)
 def test_cdfast(distr):
     """Test all functionality related to fast coordinate descent."""
     scaler = StandardScaler()
@@ -311,7 +304,7 @@ def test_cdfast(distr):
     # Batch gradient not available for gamma
     if distr == 'gamma':
         return
-        
+
     glm = GLM(distr, solver='cdfast')
 
     np.random.seed(glm.random_state)


### PR DESCRIPTION
-  Parameterized tests which contained loops over distributions.
- Added flake8 for test directory too (it was already adhering to style mostly, I fixed like 5 things).
- Verbose output from testing, and slowest running tests. Makes it easier to debug CI.

**The output from testing is:**

```
============================= test session starts ==============================
platform linux -- Python 3.7.2, pytest-4.3.1, py-1.8.0, pluggy-0.9.0 -- /home/tommy/anaconda3/envs/pyglmnet/bin/python
cachedir: .pytest_cache
rootdir: /home/tommy/Desktop/pyglmnet, inifile:
plugins: cov-2.6.1
collected 32 items                                                             

tests/test_metrics.py::test_deviance PASSED                              [  3%]
tests/test_metrics.py::test_pseudoR2 PASSED                              [  6%]
tests/test_metrics.py::test_accuracy PASSED                              [  9%]
tests/test_pyglmnet.py::test_gradients[gaussian] PASSED                  [ 12%]
tests/test_pyglmnet.py::test_gradients[binomial] PASSED                  [ 15%]
tests/test_pyglmnet.py::test_gradients[softplus] PASSED                  [ 18%]
tests/test_pyglmnet.py::test_gradients[poisson] PASSED                   [ 21%]
tests/test_pyglmnet.py::test_gradients[probit] PASSED                    [ 25%]
tests/test_pyglmnet.py::test_gradients[gamma] PASSED                     [ 28%]
tests/test_pyglmnet.py::test_tikhonov PASSED                             [ 31%]
tests/test_pyglmnet.py::test_group_lasso PASSED                          [ 34%]
tests/test_pyglmnet.py::test_glmnet[gaussian] PASSED                     [ 37%]
tests/test_pyglmnet.py::test_glmnet[binomial] PASSED                     [ 40%]
tests/test_pyglmnet.py::test_glmnet[softplus] PASSED                     [ 43%]
tests/test_pyglmnet.py::test_glmnet[poisson] PASSED                      [ 46%]
tests/test_pyglmnet.py::test_glmnet[probit] PASSED                       [ 50%]
tests/test_pyglmnet.py::test_glmnet[gamma] PASSED                        [ 53%]
tests/test_pyglmnet.py::test_glmcv[gaussian] PASSED                      [ 56%]
tests/test_pyglmnet.py::test_glmcv[binomial] PASSED                      [ 59%]
tests/test_pyglmnet.py::test_glmcv[softplus] PASSED                      [ 62%]
tests/test_pyglmnet.py::test_glmcv[poisson] PASSED                       [ 65%]
tests/test_pyglmnet.py::test_glmcv[probit] PASSED                        [ 68%]
tests/test_pyglmnet.py::test_glmcv[gamma] PASSED                         [ 71%]
tests/test_pyglmnet.py::test_cv PASSED                                   [ 75%]
tests/test_pyglmnet.py::test_cdfast[gaussian] PASSED                     [ 78%]
tests/test_pyglmnet.py::test_cdfast[binomial] PASSED                     [ 81%]
tests/test_pyglmnet.py::test_cdfast[softplus] PASSED                     [ 84%]
tests/test_pyglmnet.py::test_cdfast[poisson] PASSED                      [ 87%]
tests/test_pyglmnet.py::test_cdfast[probit] PASSED                       [ 90%]
tests/test_pyglmnet.py::test_cdfast[gamma] PASSED                        [ 93%]
tests/test_pyglmnet.py::test_fetch_datasets PASSED                       [ 96%]
tests/test_pyglmnet.py::test_random_state_consistency PASSED             [100%]

=============================== warnings summary ===============================
tests/test_pyglmnet.py::test_fetch_datasets
  /home/tommy/anaconda3/envs/pyglmnet/lib/python3.7/importlib/_bootstrap.py:219: RuntimeWarning: numpy.ufunc size changed, may indicate binary incompatibility. Expected 192 from C header, got 216 from PyObject
    return f(*args, **kwds)

-- Docs: https://docs.pytest.org/en/latest/warnings.html

----------- coverage: platform linux, python 3.7.2-final-0 -----------
Name                   Stmts   Miss Branch BrPart  Cover
--------------------------------------------------------
pyglmnet/__init__.py       4      0      0      0   100%
pyglmnet/base.py          66     28     34      8    56%
pyglmnet/metrics.py       21      0      6      0   100%
pyglmnet/pyglmnet.py     487     73    200     26    79%
pyglmnet/utils.py         43     25     10      4    42%
--------------------------------------------------------
TOTAL                    621    126    250     38    75%

========================== slowest 10 test durations ===========================
14.56s call     tests/test_pyglmnet.py::test_random_state_consistency
10.41s call     tests/test_pyglmnet.py::test_glmcv[probit]
9.20s call     tests/test_pyglmnet.py::test_cv
3.34s call     tests/test_pyglmnet.py::test_glmcv[poisson]
2.48s call     tests/test_pyglmnet.py::test_fetch_datasets
2.40s call     tests/test_pyglmnet.py::test_glmcv[softplus]
2.29s call     tests/test_pyglmnet.py::test_glmcv[gaussian]
2.26s call     tests/test_pyglmnet.py::test_glmcv[gamma]
2.26s call     tests/test_pyglmnet.py::test_glmcv[binomial]
0.32s call     tests/test_metrics.py::test_deviance
==================== 32 passed, 1 warnings in 52.02 seconds ====================
```