### PR TITLE
Bug Fix: GLMCV does not pass group argument

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -27,6 +27,7 @@ BUG
     - Fixed incorrect proximal operator for group lasso by `Yu Umegaki`_.
     - Changed stopping criteria for convergence (a threshold on the change in objective value) which
       stopped too learly. The new criteria is a threshold on the norm of the gradient, by `Pavan Ramkumar`_. 
+    - Fixed `group` parameter not being passed for Group Lasso by `Beibin Li`_.
 
 API
 ~~~
@@ -65,3 +66,4 @@ Changelog
 .. _Ravi Garg: https://github.com/ravigarg27
 .. _Yu Umegaki: https://github.com/AnchorBlues
 .. _Giovanni De Toni: https://github.com/geektoni
+.. _Beibin Li: https://github.com/BeibinLi

--- a/pyglmnet/datasets.py
+++ b/pyglmnet/datasets.py
@@ -195,9 +195,9 @@ def fetch_group_lasso_datasets():
         return feature_vector
 
     positive_url = \
-        "http://genes.mit.edu/burgelab/maxent/ssdata/MEMset/train5_hs"
+        "http://hollywood.mit.edu/burgelab/maxent/ssdata/MEMset/train5_hs"
     negative_url = \
-        "http://genes.mit.edu/burgelab/maxent/ssdata/MEMset/train0_5_hs"
+        "http://hollywood.mit.edu/burgelab/maxent/ssdata/MEMset/train0_5_hs"
 
     if sys.version_info[0] == 3:
         pos_file = tempfile.NamedTemporaryFile('w+', buffering=1)

--- a/pyglmnet/pyglmnet.py
+++ b/pyglmnet/pyglmnet.py
@@ -699,7 +699,7 @@ class GLM(BaseEstimator):
         # checks for group
         if self.group is not None:
             self.group = np.array(self.group)
-            self.group.dtype = np.int64
+            self.group = self.group.astype(np.int64)
             # shape check
             if self.group.shape[0] != X.shape[1]:
                 raise ValueError('group should be (n_features,)')
@@ -1113,6 +1113,7 @@ class GLMCV(object):
             glm = GLM(distr=self.distr,
                       alpha=self.alpha,
                       Tau=self.Tau,
+                      group=self.group,
                       reg_lambda=0.1,
                       solver=self.solver,
                       learning_rate=self.learning_rate,


### PR DESCRIPTION
1. As above
2. Suppress warning for numpy type conversion. 
3. TODO: need to update group lasso example, because it uses the "group" parameter.