### PR TITLE
Python2 import fix in datasets.py

### DIFF
--- a/pyglmnet/datasets.py
+++ b/pyglmnet/datasets.py
@@ -8,8 +8,12 @@ import tempfile
 import itertools
 import numpy as np
 from scipy.misc import comb
-from urllib.request import urlretrieve
-
+try:
+    # Python 3
+    from urllib.request import urlretrieve
+except ImportError:
+    # Python 2 (?)
+    from urllib import urlretrieve
 pbar = None
 
 

--- a/pyglmnet/datasets.py
+++ b/pyglmnet/datasets.py
@@ -12,7 +12,7 @@ try:
     # Python 3
     from urllib.request import urlretrieve
 except ImportError:
-    # Python 2 (?)
+    # Python 2
     from urllib import urlretrieve
 pbar = None
 


### PR DESCRIPTION
This PR fixes an import of urllib for Python 2, without compromising Python 3 functionality.
https://github.com/glm-tools/pyglmnet/issues/292
