### PR TITLE
include nonzero lambda in glm tests

### DIFF
--- a/tests/test_pyglmnet.py
+++ b/tests/test_pyglmnet.py
@@ -184,12 +184,12 @@ def test_glmnet(distr, reg_lambda):
 
         alpha = 0.
         loss_trace = list()
+        eta = 2.0
+        group = None
+        Tau = None
 
         def callback(beta):
             Tau = None
-            eta = 2.0
-            group = None
-
             loss_trace.append(
                 _loss(distr, alpha, Tau, reg_lambda,
                       X_train, y_train, eta, group, beta))
@@ -206,12 +206,12 @@ def test_glmnet(distr, reg_lambda):
         assert(np.all(np.diff(loss_trace) <= 1e-7))
 
         # verify loss at convergence = loss when beta=beta_
-        l_true = _loss(distr, 0., np.eye(beta.shape[0]), 0.,
-                       X_train, y_train, 2.0, None,
+        l_true = _loss(distr, alpha, Tau, reg_lambda,
+                       X_train, y_train, eta, group,
                        np.concatenate(([beta0], beta)))
         assert_allclose(loss_trace[-1], l_true, rtol=1e-4, atol=1e-5)
         # beta=beta_ when reg_lambda = 0.
-        if reg_lambda == 0.0:
+        if reg_lambda == 0.:
             assert_allclose(beta, glm.beta_, rtol=0.05, atol=1e-2)
         betas_.append(glm.beta_)
 

--- a/tests/test_pyglmnet.py
+++ b/tests/test_pyglmnet.py
@@ -150,7 +150,8 @@ def test_group_lasso():
 
 
 @pytest.mark.parametrize("distr", ALLOWED_DISTRS)
-def test_glmnet(distr):
+@pytest.mark.parametrize("reg_lambda", [0.0, 0.1])
+def test_glmnet(distr, reg_lambda):
     """Test glmnet."""
     raises(ValueError, GLM, distr='blah')
     raises(ValueError, GLM, distr='gaussian', max_iter=1.8)
@@ -182,7 +183,6 @@ def test_glmnet(distr):
                                sample=False)
 
         alpha = 0.
-        reg_lambda = 0.
         loss_trace = list()
 
         def callback(beta):
@@ -211,7 +211,8 @@ def test_glmnet(distr):
                        np.concatenate(([beta0], beta)))
         assert_allclose(loss_trace[-1], l_true, rtol=1e-4, atol=1e-5)
         # beta=beta_ when reg_lambda = 0.
-        assert_allclose(beta, glm.beta_, rtol=0.05, atol=1e-2)
+        if reg_lambda == 0.0:
+            assert_allclose(beta, glm.beta_, rtol=0.05, atol=1e-2)
         betas_.append(glm.beta_)
 
         y_pred = glm.predict(X_train)

--- a/tests/test_pyglmnet.py
+++ b/tests/test_pyglmnet.py
@@ -205,13 +205,14 @@ def test_glmnet(distr, reg_lambda):
         # verify loss decreases
         assert(np.all(np.diff(loss_trace) <= 1e-7))
 
-        # verify loss at convergence = loss when beta=beta_
-        l_true = _loss(distr, alpha, Tau, reg_lambda,
-                       X_train, y_train, eta, group,
-                       np.concatenate(([beta0], beta)))
-        assert_allclose(loss_trace[-1], l_true, rtol=1e-4, atol=1e-5)
-        # beta=beta_ when reg_lambda = 0.
+        # true loss and beta should be recovered when reg_lambda == 0
         if reg_lambda == 0.:
+            # verify loss at convergence = loss when beta=beta_
+            l_true = _loss(distr, alpha, Tau, reg_lambda,
+                           X_train, y_train, eta, group,
+                           np.concatenate(([beta0], beta)))
+            assert_allclose(loss_trace[-1], l_true, rtol=1e-4, atol=1e-5)
+            # beta=beta_ when reg_lambda = 0.
             assert_allclose(beta, glm.beta_, rtol=0.05, atol=1e-2)
         betas_.append(glm.beta_)
 


### PR DESCRIPTION
test_glmnet is currently only run with `reg_lambda=0.`, which means things like calls to `self._prox` effectively have no impact and don't get tested for all `ALLOWED_DISTRS`.