### PR TITLE
MRG: Convergence

### DIFF
--- a/pyglmnet/pyglmnet.py
+++ b/pyglmnet/pyglmnet.py
@@ -812,7 +812,7 @@ class GLM(BaseEstimator):
         # Iterative updates
         for t in range(0, self.max_iter):
             self.n_iter_ += 1
-            beta_old = deepcopy(beta)
+            beta_old = beta.copy()
             if self.solver == 'batch-gradient':
                 grad = _grad_L2loss(self.distr,
                                     alpha, self.Tau,

--- a/pyglmnet/pyglmnet.py
+++ b/pyglmnet/pyglmnet.py
@@ -818,15 +818,6 @@ class GLM(BaseEstimator):
                                     alpha, self.Tau,
                                     reg_lambda, X, y, self.eta,
                                     beta, self.fit_intercept)
-
-                # Convergence by gradient norm tolerance
-                max_grad = np.max(grad)
-                if t > 1 and self.learning_rate * max_grad < tol:
-                    msg = ('\tGradient norm tolerance. ' +
-                           'Converged in {0:d} iterations'.format(t))
-                    logger.info(msg)
-                    break
-
                 # Update
                 beta = beta - self.learning_rate * grad
 

--- a/pyglmnet/pyglmnet.py
+++ b/pyglmnet/pyglmnet.py
@@ -517,7 +517,7 @@ class GLM(BaseEstimator):
     >>> glm.beta0_ # The intercept
     1.005380485553247
     >>> glm.beta_ # The coefficients
-    array([ 1.90217526, -0.78781579, -0.        ,  0.03227754])
+    array([ 1.90216711, -0.78782533, -0.        ,  0.03227455])
     >>> y_pred = glm.predict(X)
 
 

--- a/pyglmnet/pyglmnet.py
+++ b/pyglmnet/pyglmnet.py
@@ -515,7 +515,7 @@ class GLM(BaseEstimator):
     >>> glm = GLM(distr='gaussian', verbose=False, random_state=random_state)
     >>> glm = glm.fit(X, y)
     >>> glm.beta0_ # The intercept
-    1.005377890812967
+    1.005380485553247
     >>> glm.beta_ # The coefficients
     array([ 1.90217526, -0.78781579, -0.        ,  0.03227754])
     >>> y_pred = glm.predict(X)

--- a/tests/test_pyglmnet.py
+++ b/tests/test_pyglmnet.py
@@ -203,7 +203,7 @@ def test_glmnet(distr, reg_lambda, fit_intercept):
                       fit_intercept=fit_intercept))
 
         glm = GLM(distr, learning_rate=learning_rate,
-                  reg_lambda=reg_lambda, tol=1e-3, max_iter=5000,
+                  reg_lambda=reg_lambda, tol=1e-5, max_iter=5000,
                   alpha=alpha, solver=solver, score_metric=score_metric,
                   random_state=random_state, callback=callback,
                   fit_intercept=fit_intercept)
@@ -397,8 +397,7 @@ def test_fetch_datasets():
 
 
 def test_random_state_consistency():
-    """ Test model's random_state """
-
+    """Test model's random_state."""
     # Generate the dataset
     n_samples, n_features = 1000, 10
 
@@ -421,6 +420,7 @@ def test_random_state_consistency():
     assert_array_equal(ypred_a, ypred_b)
     # Consistency between different run of the same model
     assert_array_equal(ypred_b, ypred_c)
+    # assert_allclose(ypred_b, ypred_c, atol=1e-5, rtol=1e-4)
 
     # Test also cross-validation
     glm_cv_a = GLMCV(distr="gaussian", cv=3, random_state=1)

--- a/tests/test_pyglmnet.py
+++ b/tests/test_pyglmnet.py
@@ -419,8 +419,7 @@ def test_random_state_consistency():
     # Consistency between two different models
     assert_array_equal(ypred_a, ypred_b)
     # Consistency between different run of the same model
-    assert_array_equal(ypred_b, ypred_c)
-    # assert_allclose(ypred_b, ypred_c, atol=1e-5, rtol=1e-4)
+    assert_allclose(ypred_b, ypred_c, atol=1e-5, rtol=1e-4)
 
     # Test also cross-validation
     glm_cv_a = GLMCV(distr="gaussian", cv=3, random_state=1)

--- a/tests/test_pyglmnet.py
+++ b/tests/test_pyglmnet.py
@@ -307,7 +307,6 @@ def test_cv():
 @pytest.mark.parametrize("solver", ['batch-gradient', 'cdfast'])
 def test_compare_sklearn(solver):
     """Test results against sklearn."""
-
     def rmse(a, b):
         return np.sqrt(np.mean((a - b) ** 2))
 


### PR DESCRIPTION
A few things to note (see review comments):

- The criterion based on (relative) parameter change per iteration is sufficient for all tests to pass and speed up all examples despite strict default tolerance (`tol=1e-6`).

- However, I am leaving the gradient norm based criterion in the code for readability sake. My main concern is that to make the gradient-based convergence work well, we have to calculate the projected gradient (i.e. what remains after the proximal operator has been applied) and then take the norm on it. Unfortunately that required more digging into the implementation of `_prox` for all corner cases and I ran out of time. So I would recommend removing this criterion entirely for this PR.

- As a consequence of this PR, one test fails: `test_random_state_consistency`. However the failure is easily understood and can be traced back to cold (random) vs. warm initialization of beta. I've recommended a modification to the test: use `assert_allclose` instead of `assert_equal` (commented out for now; I wanted to demo the failed test first)