### PR TITLE
MAINT: quick link to artifacts

### DIFF
--- a/.circleci/artifact_path
+++ b/.circleci/artifact_path
@@ -1,0 +1,1 @@
+0/html/index.html

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 jobs:
-    build:
+    build_docs:
         docker:
             - image: circleci/python:3.7.0-stretch-node-browsers
         steps:
@@ -36,3 +36,9 @@ jobs:
             - store_artifacts:
                 path: doc/_build/html/
                 destination: html
+
+workflows:
+  version: 2
+  search_build:
+    jobs:
+      - build_docs


### PR DESCRIPTION
just need to enable this: https://github.com/larsoner/circleci-artifacts-redirector

and then we should get a quick link to the artifacts even for people who are not maintainers.