### PR TITLE
[MRG] Show progress when training a GLM object.

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -12,6 +12,7 @@ Current
 -------
 
     - Add method :method:`pyglmnet.GLM.plot_convergence` to inspect convergence by `Mainak Jas`_.
+    - Add `tqdm` to nicely visualize training time both from notebooks and command line scripts by `Giovanni De Toni`_.
 
 Changelog
 ~~~~~~~~~

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pytest-cov
 coverage
 flake8
 pydocstyle
+tqdm>=4.46


### PR DESCRIPTION
Addressing issue #379.

GLM objects can show the current training progress statistics (remaining time, iterations/sec, etc.).
This is true also for GLMCV objects.

* Add `tqdm` (https://github.com/tqdm/tqdm/) as a requirement.
