### PR TITLE
Remove broken link in docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -183,4 +183,3 @@ MIT License Copyright (c) 2016-2019 Pavan Ramkumar
 .. |JOSS| image:: https://joss.theoj.org/papers/10.21105/joss.01959/status.svg
    :target: https://doi.org/10.21105/joss.01959
 .. _[Documentation (stable version)]: http://glm-tools.github.io/pyglmnet
-.. _[Documentation (development version)]: https://circleci.com/api/v1.1/project/github/glm-tools/pyglmnet/latest/artifacts/0/html/index.html?branch=master

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -15,7 +15,6 @@ elastic net, group lasso, and Tikhonov regularization.
 
 [`Repository <https://github.com/glm-tools/pyglmnet>`_]
 [`Documentation (stable release) <http://glm-tools.github.io/pyglmnet>`_]
-[`Documentation (development version) <https://circleci.com/api/v1.1/project/github/glm-tools/pyglmnet/latest/artifacts/0/html/index.html?branch=master>`_]
 
 A brief introduction to GLMs
 ============================


### PR DESCRIPTION
The link to development version of documentation was pointing to a CircleCI artifact which would get removed in 30 days from being created - this would need to be hosted elsewhere so it's best to remove the link to avoid confusing users.