### PR TITLE
np.float() to float() in pyglmnet.py

### DIFF
--- a/pyglmnet/pyglmnet.py
+++ b/pyglmnet/pyglmnet.py
@@ -235,7 +235,7 @@ def _grad_L2loss(distr, alpha, Tau, reg_lambda, X, y, eta, theta, beta,
                  fit_intercept=True):
     """The gradient."""
     n_samples, n_features = X.shape
-    n_samples = np.float(n_samples)
+    n_samples = float(n_samples)
 
     if Tau is None:
         if fit_intercept:


### PR DESCRIPTION
np.float() is deprecated for numpy >=1.24, replaced by float()